### PR TITLE
fix: 카카오 로그인 진행 시 비밀번호 칸 "" 빈 문자열로 수정

### DIFF
--- a/app/src/main/java/com/blank/bookverse/data/repository/LoginRepository.kt
+++ b/app/src/main/java/com/blank/bookverse/data/repository/LoginRepository.kt
@@ -86,7 +86,7 @@ class LoginRepository @Inject constructor(
                 // 회원가입 처리
                 val authResult = firebaseAuth.createUserWithEmailAndPassword(
                     registerModel.memberId,
-                    registerModel.memberPassword
+                    registerModel.memberId
                 ).await()
 
                 val uid = authResult.user?.uid ?: throw Exception("회원가입 실패: UID 없음")
@@ -103,7 +103,7 @@ class LoginRepository @Inject constructor(
                 // 로그인 처리
                 val authResult = firebaseAuth.signInWithEmailAndPassword(
                     registerModel.memberId,
-                    registerModel.memberPassword
+                    registerModel.memberId
                 ).await()
                 authResult.user  // 로그인 성공한 FirebaseUser 반환
             }

--- a/app/src/main/java/com/blank/bookverse/presentation/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/blank/bookverse/presentation/ui/login/LoginViewModel.kt
@@ -112,7 +112,7 @@ class LoginViewModel @Inject constructor(
                                     memberName = nickname,
                                     memberProfileImage = "",
                                     memberId = email,
-                                    memberPassword = email,
+                                    memberPassword = "",
                                     memberPhoneNumber = "",
                                     memberNickName = nickname,
                                     LoginType = "카카오",


### PR DESCRIPTION
카카오 로그인 진행 시 비밀번호 칸 "" 빈 문자열로 수정